### PR TITLE
update submodules to reflect mwlib's change-of-address

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mwlib"]
 	path = mwlib
-	url = git://code.pediapress.com/mwlib
+	url = https://github.com/pediapress/mwlib.git


### PR DESCRIPTION
The `mwlib` repository has moved to github, so the submodule was broken. This is a humble patch to fix this.
