### PR TITLE
Update iki-scatter-revs.rb

### DIFF
--- a/iki-scatter-revs.rb
+++ b/iki-scatter-revs.rb
@@ -16,7 +16,7 @@
 
 
 require 'rubygems'
-require 'node-callback'
+require_relative 'node-callback'
 require 'time'
 
 require 'fileutils' # for mkdir_p


### PR DESCRIPTION
Was unable to load node-callback because it wasn't looking in the relative directory, so this seems to fix that.
